### PR TITLE
LC-3075: Fix domain allowlist and organisation cache bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  identity:
-    build:
-      dockerfile: Dockerfile
-      target: develop
-    ports:
-      - 8080:8080
-    env_file:
-      - int.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  identity:
+    build:
+      dockerfile: Dockerfile
+      target: develop
+    ports:
+      - 8080:8080
+    env_file:
+      - int.env

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationController.java
@@ -144,6 +144,6 @@ public class AgencyTokenVerificationController {
     }
 
     private void addOrganisationsToModel(Model model) {
-        model.addAttribute("organisations", civilServantRegistryClient.getAllOrganisationsFromCache());
+        model.addAttribute("organisations", civilServantRegistryClient.getAllOrganisations());
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/signup/SignupController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/signup/SignupController.java
@@ -9,6 +9,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.domain.Invite;
@@ -81,6 +82,8 @@ public class SignupController {
 
     private final ICivilServantRegistryClient civilServantRegistryClient;
 
+    private final CsrsService csrsService;
+
     private final AgencyTokenCapacityService agencyTokenCapacityService;
 
     private final Utils utils;
@@ -90,12 +93,14 @@ public class SignupController {
     public SignupController(InviteService inviteService,
                             IdentityService identityService,
                             ICivilServantRegistryClient civilServantRegistryClient,
+                            CsrsService csrsService,
                             AgencyTokenCapacityService agencyTokenCapacityService,
                             Utils utils,
                             Clock clock) {
         this.inviteService = inviteService;
         this.identityService = identityService;
         this.civilServantRegistryClient = civilServantRegistryClient;
+        this.csrsService = csrsService;
         this.agencyTokenCapacityService = agencyTokenCapacityService;
         this.utils = utils;
         this.clock = clock;
@@ -287,7 +292,7 @@ public class SignupController {
         log.info("Invite email {} accessing enter organisation screen for validation", invite.getForEmail());
 
         final String domain = utils.getDomainFromEmailAddress(invite.getForEmail());
-        List<OrganisationalUnit> organisations = civilServantRegistryClient.getFilteredOrganisations(domain);
+        List<OrganisationalUnit> organisations = csrsService.getOrganisationalUnitsByDomain(domain);
 
         model.addAttribute(ORGANISATIONS_ATTRIBUTE, organisations);
         model.addAttribute(CHOOSE_ORGANISATION_FORM, new ChooseOrganisationForm());
@@ -319,7 +324,7 @@ public class SignupController {
         log.info("Invite email {} selected organisation {}", invite.getForEmail(), orgCode);
 
         final String domain = utils.getDomainFromEmailAddress(invite.getForEmail());
-        List<OrganisationalUnit> organisations = civilServantRegistryClient.getFilteredOrganisations(domain);
+        List<OrganisationalUnit> organisations = csrsService.getOrganisationalUnitsByDomain(domain);
 
         Optional<OrganisationalUnit> selectedOrgUnitOptional =
                 organisations

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
@@ -1,0 +1,40 @@
+package uk.gov.cabinetoffice.csl.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
+import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
+
+import java.util.List;
+import java.util.Locale;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@Slf4j
+public class CsrsService {
+    private ICivilServantRegistryClient civilServantRegistryClient;
+
+    public CsrsService(ICivilServantRegistryClient civilServantRegistryClient){
+        this.civilServantRegistryClient = civilServantRegistryClient;
+    }
+
+    public boolean domainIsAllowlisted(String domain) {
+        return civilServantRegistryClient.getAllowListDomains().contains(domain.toLowerCase(Locale.ROOT));
+    }
+
+    public List<OrganisationalUnit> getAllOrganisationalUnits() {
+        return civilServantRegistryClient.getAllOrganisations();
+    }
+
+    public List<OrganisationalUnit> getOrganisationalUnitsByDomain(String domain) {
+        return this.getAllOrganisationalUnits()
+                .stream()
+                .filter(o -> o.doesDomainExist(domain))
+                .collect(toList());
+    }
+
+    public boolean domainIsValid(String domain) {
+        return !this.getOrganisationalUnitsByDomain(domain).isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
@@ -38,6 +38,7 @@ public class IdentityService {
     private final IdentityRepository identityRepository;
     private final CompoundRoles compoundRoles;
     private final ICivilServantRegistryClient civilServantRegistryClient;
+    private final CsrsService csrsService;
     private final PasswordEncoder passwordEncoder;
     private final Utils utils;
     private final Clock clock;
@@ -178,11 +179,11 @@ public class IdentityService {
 
     public boolean isValidEmailDomain(String email) {
         final String domain = utils.getDomainFromEmailAddress(email);
-        return civilServantRegistryClient.isDomainValid(domain);
+        return csrsService.domainIsValid(domain);
     }
 
     public boolean isDomainAllowListed(String domain) {
-        return civilServantRegistryClient.isDomainAllowListed(domain);
+        return csrsService.domainIsAllowlisted(domain);
     }
 
     public boolean isDomainInAnAgencyToken(String domain) {

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/client/csrs/ICivilServantRegistryClient.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/client/csrs/ICivilServantRegistryClient.java
@@ -1,7 +1,6 @@
 package uk.gov.cabinetoffice.csl.service.client.csrs;
 
 import uk.gov.cabinetoffice.csl.dto.AgencyToken;
-import uk.gov.cabinetoffice.csl.dto.DomainsResponse;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
 
 import java.util.List;
@@ -9,25 +8,15 @@ import java.util.Optional;
 
 public interface ICivilServantRegistryClient {
 
-    boolean isDomainAllowListed(String domain);
-
-    boolean isDomainValid(String domain);
-
     boolean isDomainInAnAgencyToken(String domain);
 
     boolean isDomainInAnAgencyTokenWithOrg(String domain, String orgCode);
 
-    DomainsResponse getAllowListDomains();
-
-    List<String> getAllowListDomainsFromCache();
+    List<String> getAllowListDomains();
 
     void evictAllowListDomainCache();
 
-    List<OrganisationalUnit> getFilteredOrganisations(String domain);
-
     List<OrganisationalUnit> getAllOrganisations();
-
-    List<OrganisationalUnit> getAllOrganisationsFromCache();
 
     void evictOrganisationsCache();
 

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationControllerTest.java
@@ -85,7 +85,7 @@ public class AgencyTokenVerificationControllerTest {
     public void setup() {
         organisations = new ArrayList<>();
         organisations.add(new OrganisationalUnit());
-        when(civilServantRegistryClient.getAllOrganisationsFromCache()).thenReturn(organisations);
+        when(civilServantRegistryClient.getAllOrganisations()).thenReturn(organisations);
     }
 
     @Test

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/signup/SignupControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/signup/SignupControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cabinetoffice.csl.dto.AgencyToken;
 import uk.gov.cabinetoffice.csl.dto.Domain;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
+import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.domain.*;
@@ -79,6 +80,9 @@ public class SignupControllerTest {
     @MockBean
     private AgencyTokenCapacityService agencyTokenCapacityService;
 
+    @MockBean
+    private CsrsService csrsService;
+
     private final Clock clock = Clock.fixed(Instant.parse("2024-01-01T10:00:00.000Z"),
             ZoneId.of("Europe/London"));
 
@@ -86,6 +90,7 @@ public class SignupControllerTest {
     private final String GENERIC_DOMAIN = "domain.com";
     private final String GENERIC_CODE = "ABC123";
     private final String GENERIC_ORG_CODE = "org123";
+
 
     private Invite generateBasicInvite(boolean authorised) {
         Invite i = new Invite();
@@ -439,7 +444,7 @@ public class SignupControllerTest {
 
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getFilteredOrganisations(GENERIC_DOMAIN)).thenReturn(orgs);
+        when(csrsService.getOrganisationalUnitsByDomain(GENERIC_DOMAIN)).thenReturn(orgs);
 
         mockMvc.perform(
                         get("/signup/chooseOrganisation/" + GENERIC_CODE)
@@ -455,7 +460,7 @@ public class SignupControllerTest {
         List<OrganisationalUnit> orgs = Collections.singletonList(org);
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getFilteredOrganisations(GENERIC_DOMAIN)).thenReturn(orgs);
+        when(csrsService.getOrganisationalUnitsByDomain(GENERIC_DOMAIN)).thenReturn(orgs);
         mockMvc.perform(
                         post("/signup/chooseOrganisation/" + GENERIC_CODE)
                                 .with(csrf())
@@ -472,7 +477,8 @@ public class SignupControllerTest {
         List<OrganisationalUnit> orgs = Collections.singletonList(org);
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getFilteredOrganisations(GENERIC_DOMAIN)).thenReturn(orgs);
+        when(csrsService.getOrganisationalUnitsByDomain(GENERIC_DOMAIN)).thenReturn(orgs);
+
         mockMvc.perform(
                         post("/signup/chooseOrganisation/" + GENERIC_CODE)
                                 .with(csrf())

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
@@ -53,6 +53,9 @@ public class IdentityServiceTest {
     private ICivilServantRegistryClient civilServantRegistryClient;
 
     @Mock
+    private CsrsService csrsService;
+
+    @Mock
     private PasswordEncoder passwordEncoder;
 
     private final Utils utils = new Utils();
@@ -67,6 +70,7 @@ public class IdentityServiceTest {
                 identityRepository,
                 new CompoundRolesRepository(),
                 civilServantRegistryClient,
+                csrsService,
                 passwordEncoder,
                 utils,
                 clock
@@ -125,7 +129,7 @@ public class IdentityServiceTest {
 
         when(inviteService.getInviteForCode(code)).thenReturn(invite);
         when(passwordEncoder.encode("password")).thenReturn("password");
-        when(civilServantRegistryClient.isDomainAllowListed(domain)).thenReturn(true);
+        when(csrsService.domainIsAllowlisted(domain)).thenReturn(true);
 
         identityService.createIdentityFromInviteCode(code, "password", agencyToken);
 


### PR DESCRIPTION
This change:

* Create a new service `CsrsService`
* Create new functions in `CsrsService`: `domainIsAllowlisted()`, `getAllOrganisationalUnits()`, `getOrganisationalUnitsByDomain()` and `domainIsValid()`.
* Refactor `CivilServantRegistryClient` to combine and rename methods.
* Refactor various classes to call `CsrsService` instead of `CivilServantRegistryClient`