### PR TITLE
LC-3075: Fix domain allowlist and organisation cache bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  identity:
-    build:
-      dockerfile: Dockerfile
-      target: develop
-    ports:
-      - 8080:8080
-    env_file:
-      - int.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  identity:
+    build:
+      dockerfile: Dockerfile
+      target: develop
+    ports:
+      - 8080:8080
+    env_file:
+      - int.env

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationController.java
@@ -16,11 +16,7 @@ import uk.gov.cabinetoffice.csl.dto.VerificationCodeType;
 import uk.gov.cabinetoffice.csl.exception.NotEnoughSpaceAvailableException;
 import uk.gov.cabinetoffice.csl.exception.ResourceNotFoundException;
 import uk.gov.cabinetoffice.csl.exception.VerificationCodeTypeNotFound;
-import uk.gov.cabinetoffice.csl.service.AgencyTokenCapacityService;
-import uk.gov.cabinetoffice.csl.service.EmailUpdateService;
-import uk.gov.cabinetoffice.csl.service.ReactivationService;
-import uk.gov.cabinetoffice.csl.service.VerificationCodeDeterminationService;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
+import uk.gov.cabinetoffice.csl.service.*;
 import uk.gov.cabinetoffice.csl.util.Utils;
 
 import static java.lang.String.format;
@@ -43,8 +39,6 @@ public class AgencyTokenVerificationController {
 
     private final EmailUpdateService emailUpdateService;
 
-    private final ICivilServantRegistryClient civilServantRegistryClient;
-
     private final Utils utils;
 
     private final AgencyTokenCapacityService agencyTokenCapacityService;
@@ -52,6 +46,8 @@ public class AgencyTokenVerificationController {
     private final ReactivationService reactivationService;
 
     private final VerificationCodeDeterminationService verificationCodeDeterminationService;
+
+    private final CsrsService csrsService;
 
     @GetMapping(path = "/{code}")
     public String enterToken(Model model, @PathVariable String code) {
@@ -92,7 +88,7 @@ public class AgencyTokenVerificationController {
             String domainFromEmailAddress =
                     utils.getDomainFromEmailAddress(verificationCodeDetermination.getEmail());
 
-            AgencyToken agencyToken = civilServantRegistryClient
+            AgencyToken agencyToken = csrsService
                     .getAgencyToken(domainFromEmailAddress, token, organisation)
                     .orElseThrow(() -> new ResourceNotFoundException("Agency Token for DomainTokenOrganisation Not Found"));
 
@@ -144,6 +140,6 @@ public class AgencyTokenVerificationController {
     }
 
     private void addOrganisationsToModel(Model model) {
-        model.addAttribute("organisations", civilServantRegistryClient.getAllOrganisations());
+        model.addAttribute("organisations", csrsService.getAllOrganisationalUnits());
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationController.java
@@ -144,6 +144,6 @@ public class AgencyTokenVerificationController {
     }
 
     private void addOrganisationsToModel(Model model) {
-        model.addAttribute("organisations", civilServantRegistryClient.getAllOrganisationsFromCache());
+        model.addAttribute("organisations", civilServantRegistryClient.getAllOrganisations());
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/cachereset/CacheResetController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/cachereset/CacheResetController.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
+import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.client.identity.IIdentityClient;
 
 @AllArgsConstructor
@@ -15,7 +15,7 @@ import uk.gov.cabinetoffice.csl.service.client.identity.IIdentityClient;
 public class CacheResetController {
 
     private final IIdentityClient identityClient;
-    private final ICivilServantRegistryClient civilServantRegistryClient;
+    private final CsrsService csrsService;
 
     @GetMapping(path = "/service-token", produces = "application/json")
     public ResponseEntity<?> evictServiceTokenFromCache() {
@@ -25,13 +25,13 @@ public class CacheResetController {
 
     @GetMapping(path = "/allowlist-domains", produces = "application/json")
     public ResponseEntity<?> evictAllowListDomainCache() {
-        civilServantRegistryClient.evictAllowListDomainCache();
+        csrsService.evictAllowListDomainCache();
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 
     @GetMapping(path = "/organisations", produces = "application/json")
     public ResponseEntity<?> evictOrganisationsCache() {
-        civilServantRegistryClient.evictOrganisationsCache();
+        csrsService.evictOrganisationsCache();
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/signup/SignupController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/signup/SignupController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.domain.Invite;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
 import uk.gov.cabinetoffice.csl.dto.AgencyToken;
@@ -80,8 +79,6 @@ public class SignupController {
 
     private final IdentityService identityService;
 
-    private final ICivilServantRegistryClient civilServantRegistryClient;
-
     private final CsrsService csrsService;
 
     private final AgencyTokenCapacityService agencyTokenCapacityService;
@@ -92,14 +89,12 @@ public class SignupController {
 
     public SignupController(InviteService inviteService,
                             IdentityService identityService,
-                            ICivilServantRegistryClient civilServantRegistryClient,
                             CsrsService csrsService,
                             AgencyTokenCapacityService agencyTokenCapacityService,
                             Utils utils,
                             Clock clock) {
         this.inviteService = inviteService;
         this.identityService = identityService;
-        this.civilServantRegistryClient = civilServantRegistryClient;
         this.csrsService = csrsService;
         this.agencyTokenCapacityService = agencyTokenCapacityService;
         this.utils = utils;
@@ -365,7 +360,7 @@ public class SignupController {
         }
 
         final String domain = utils.getDomainFromEmailAddress(invite.getForEmail());
-        if (!civilServantRegistryClient.isDomainInAnAgencyTokenWithOrg(domain, organisationCode)) {
+        if (!csrsService.isDomainInAnAgencyTokenWithOrg(domain, organisationCode)) {
             return REDIRECT_CHOOSE_ORGANISATION + code;
         }
 
@@ -395,7 +390,7 @@ public class SignupController {
 
         final String domain = utils.getDomainFromEmailAddress(invite.getForEmail());
 
-        Optional<AgencyToken> agencyTokenOptional = civilServantRegistryClient.getAgencyToken(
+        Optional<AgencyToken> agencyTokenOptional = csrsService.getAgencyToken(
                 domain, form.getToken(), orgCode);
 
         if(agencyTokenOptional.isEmpty()) {

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/signup/SignupController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/signup/SignupController.java
@@ -9,6 +9,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.domain.Invite;
@@ -81,6 +82,8 @@ public class SignupController {
 
     private final ICivilServantRegistryClient civilServantRegistryClient;
 
+    private final CsrsService csrsService;
+
     private final AgencyTokenCapacityService agencyTokenCapacityService;
 
     private final Utils utils;
@@ -90,12 +93,14 @@ public class SignupController {
     public SignupController(InviteService inviteService,
                             IdentityService identityService,
                             ICivilServantRegistryClient civilServantRegistryClient,
+                            CsrsService csrsService,
                             AgencyTokenCapacityService agencyTokenCapacityService,
                             Utils utils,
                             Clock clock) {
         this.inviteService = inviteService;
         this.identityService = identityService;
         this.civilServantRegistryClient = civilServantRegistryClient;
+        this.csrsService = csrsService;
         this.agencyTokenCapacityService = agencyTokenCapacityService;
         this.utils = utils;
         this.clock = clock;
@@ -287,7 +292,7 @@ public class SignupController {
         log.info("Invite email {} accessing enter organisation screen for validation", invite.getForEmail());
 
         final String domain = utils.getDomainFromEmailAddress(invite.getForEmail());
-        List<OrganisationalUnit> organisations = civilServantRegistryClient.getFilteredOrganisations(domain);
+        List<OrganisationalUnit> organisations = csrsService.getOrganisationalUnitsByDomain(domain);
 
         model.addAttribute(ORGANISATIONS_ATTRIBUTE, organisations);
         model.addAttribute(CHOOSE_ORGANISATION_FORM, new ChooseOrganisationForm());
@@ -319,7 +324,7 @@ public class SignupController {
         log.info("Invite email {} selected organisation {}", invite.getForEmail(), orgCode);
 
         final String domain = utils.getDomainFromEmailAddress(invite.getForEmail());
-        List<OrganisationalUnit> organisations = civilServantRegistryClient.getFilteredOrganisations(domain);
+        List<OrganisationalUnit> organisations = csrsService.getOrganisationalUnitsByDomain(domain);
 
         Optional<OrganisationalUnit> selectedOrgUnitOptional =
                 organisations

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
@@ -1,0 +1,40 @@
+package uk.gov.cabinetoffice.csl.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
+import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
+
+import java.util.List;
+import java.util.Locale;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@Slf4j
+public class CsrsService {
+    private ICivilServantRegistryClient civilServantRegistryClient;
+
+    public CsrsService(ICivilServantRegistryClient civilServantRegistryClient){
+        this.civilServantRegistryClient = civilServantRegistryClient;
+    }
+
+    public boolean domainIsAllowlisted(String domain) {
+        return civilServantRegistryClient.getAllowListDomains().contains(domain.toLowerCase(Locale.ROOT));
+    }
+
+    public List<OrganisationalUnit> getAllOrganisationalUnits() {
+        return civilServantRegistryClient.getAllOrganisations();
+    }
+
+    public List<OrganisationalUnit> getOrganisationalUnitsByDomain(String domain) {
+        return this.getAllOrganisationalUnits()
+                .stream()
+                .filter(o -> o.doesDomainExist(domain))
+                .collect(toList());
+    }
+
+    public boolean domainIsValid(String domain) {
+        return !this.getOrganisationalUnitsByDomain(domain).isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
@@ -19,7 +19,7 @@ public class CsrsService {
         this.civilServantRegistryClient = civilServantRegistryClient;
     }
 
-    public boolean domainIsAllowlisted(String domain) {
+    public boolean isDomainAllowlisted(String domain) {
         return civilServantRegistryClient.getAllowListDomains().contains(domain.toLowerCase(Locale.ROOT));
     }
 
@@ -34,7 +34,7 @@ public class CsrsService {
                 .collect(toList());
     }
 
-    public boolean domainIsValid(String domain) {
+    public boolean isDomainValid(String domain) {
         return !this.getOrganisationalUnitsByDomain(domain).isEmpty();
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/CsrsService.java
@@ -2,11 +2,13 @@ package uk.gov.cabinetoffice.csl.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.cabinetoffice.csl.dto.AgencyToken;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
 import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.toList;
 
@@ -36,5 +38,33 @@ public class CsrsService {
 
     public boolean isDomainValid(String domain) {
         return !this.getOrganisationalUnitsByDomain(domain).isEmpty();
+    }
+
+    public boolean isDomainInAnAgencyToken(String domain){
+        return civilServantRegistryClient.isDomainInAnAgencyToken(domain);
+    }
+
+    public boolean isDomainInAnAgencyTokenWithOrg(String domain, String orgCode) {
+        return civilServantRegistryClient.isDomainInAnAgencyTokenWithOrg(domain, orgCode);
+    }
+
+    public void evictAllowListDomainCache(){
+        civilServantRegistryClient.evictAllowListDomainCache();
+    }
+
+    public void evictOrganisationsCache(){
+        civilServantRegistryClient.evictOrganisationsCache();
+    }
+
+    public void removeOrganisationalUnitFromCivilServant(String uid){
+        civilServantRegistryClient.removeOrganisationalUnitFromCivilServant(uid);
+    }
+
+    public Optional<AgencyToken> getAgencyToken(String domain, String token, String organisation) {
+        return civilServantRegistryClient.getAgencyToken(domain, token, organisation);
+    }
+
+    public boolean isAgencyTokenUidValidForDomain(String agencyTokenUid, String domain) {
+        return civilServantRegistryClient.isAgencyTokenUidValidForDomain(agencyTokenUid, domain);
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
@@ -179,11 +179,11 @@ public class IdentityService {
 
     public boolean isValidEmailDomain(String email) {
         final String domain = utils.getDomainFromEmailAddress(email);
-        return csrsService.domainIsValid(domain);
+        return csrsService.isDomainValid(domain);
     }
 
     public boolean isDomainAllowListed(String domain) {
-        return csrsService.domainIsAllowlisted(domain);
+        return csrsService.isDomainAllowlisted(domain);
     }
 
     public boolean isDomainInAnAgencyToken(String domain) {

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
@@ -38,6 +38,7 @@ public class IdentityService {
     private final IdentityRepository identityRepository;
     private final CompoundRoles compoundRoles;
     private final ICivilServantRegistryClient civilServantRegistryClient;
+    private final CsrsService csrsService;
     private final PasswordEncoder passwordEncoder;
     private final Utils utils;
     private final Clock clock;
@@ -178,11 +179,11 @@ public class IdentityService {
 
     public boolean isValidEmailDomain(String email) {
         final String domain = utils.getDomainFromEmailAddress(email);
-        return civilServantRegistryClient.isDomainValid(domain);
+        return csrsService.domainIsValid(domain);
     }
 
     public boolean isDomainAllowListed(String domain) {
-        return civilServantRegistryClient.isDomainAllowListed(domain);
+        return csrsService.domainIsAllowlisted(domain);
     }
 
     public boolean isDomainInAnAgencyToken(String domain) {

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/IdentityService.java
@@ -15,7 +15,6 @@ import uk.gov.cabinetoffice.csl.exception.ResourceNotFoundException;
 import uk.gov.cabinetoffice.csl.exception.UnableToAllocateAgencyTokenException;
 import uk.gov.cabinetoffice.csl.repository.CompoundRoles;
 import uk.gov.cabinetoffice.csl.repository.IdentityRepository;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.util.Utils;
 
 import java.time.Clock;
@@ -37,7 +36,6 @@ public class IdentityService {
     private final AgencyTokenCapacityService agencyTokenCapacityService;
     private final IdentityRepository identityRepository;
     private final CompoundRoles compoundRoles;
-    private final ICivilServantRegistryClient civilServantRegistryClient;
     private final CsrsService csrsService;
     private final PasswordEncoder passwordEncoder;
     private final Utils utils;
@@ -89,7 +87,7 @@ public class IdentityService {
         String agencyTokenUid = null;
         if (agencyToken != null && agencyToken.hasData()) {
             Optional<AgencyToken> agencyTokenOptional =
-                    civilServantRegistryClient.getAgencyToken(agencyToken.getDomain(),
+                    csrsService.getAgencyToken(agencyToken.getDomain(),
                             agencyToken.getToken(), agencyToken.getOrg());
             if(agencyTokenOptional.isPresent()) {
                 AgencyToken agencyTokenFromCSRS = agencyTokenOptional.get();
@@ -187,10 +185,10 @@ public class IdentityService {
     }
 
     public boolean isDomainInAnAgencyToken(String domain) {
-        return civilServantRegistryClient.isDomainInAnAgencyToken(domain);
+        return csrsService.isDomainInAnAgencyToken(domain);
     }
 
     public boolean isAgencyTokenUidValidForDomain(String agencyTokenUid, String domain) {
-        return civilServantRegistryClient.isAgencyTokenUidValidForDomain(agencyTokenUid, domain);
+        return csrsService.isAgencyTokenUidValidForDomain(agencyTokenUid, domain);
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/client/csrs/CivilServantRegistryClient.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/client/csrs/CivilServantRegistryClient.java
@@ -76,7 +76,7 @@ public class CivilServantRegistryClient implements ICivilServantRegistryClient {
     @Override
     @Cacheable("allowDomains")
     public List<String> getAllowListDomains() {
-        log.info("getAllowListDomainsFromCache: Fetching allowlist domains");
+        log.info("getAllowListDomains: Fetching allowlist domains");
         try {
             log.info("getAllowListDomains: Fetching allowlist domains from Civil Servant Registry");
             RequestEntity<Void> request = RequestEntity.get(domainsUrl).build();
@@ -111,7 +111,7 @@ public class CivilServantRegistryClient implements ICivilServantRegistryClient {
     @Override
     @Cacheable("organisations")
     public List<OrganisationalUnit> getAllOrganisations() {
-        log.info("getAllOrganisationsFromCache: Fetching all organisations");
+        log.info("getAllOrganisations: Fetching all organisations");
         log.info("getAllOrganisations: Fetching all organisations from Civil Servant Registry API");
         List<OrganisationalUnit> organisationalUnits = new ArrayList<>();
         GetOrganisationsResponse initialResponse = getOrganisations(1, 0);

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/client/csrs/ICivilServantRegistryClient.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/client/csrs/ICivilServantRegistryClient.java
@@ -1,7 +1,6 @@
 package uk.gov.cabinetoffice.csl.service.client.csrs;
 
 import uk.gov.cabinetoffice.csl.dto.AgencyToken;
-import uk.gov.cabinetoffice.csl.dto.DomainsResponse;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
 
 import java.util.List;
@@ -9,25 +8,15 @@ import java.util.Optional;
 
 public interface ICivilServantRegistryClient {
 
-    boolean isDomainAllowListed(String domain);
-
-    boolean isDomainValid(String domain);
-
     boolean isDomainInAnAgencyToken(String domain);
 
     boolean isDomainInAnAgencyTokenWithOrg(String domain, String orgCode);
 
-    DomainsResponse getAllowListDomains();
-
-    List<String> getAllowListDomainsFromCache();
+    List<String> getAllowListDomains();
 
     void evictAllowListDomainCache();
 
-    List<OrganisationalUnit> getFilteredOrganisations(String domain);
-
     List<OrganisationalUnit> getAllOrganisations();
-
-    List<OrganisationalUnit> getAllOrganisationsFromCache();
 
     void evictOrganisationsCache();
 

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationControllerTest.java
@@ -85,7 +85,7 @@ public class AgencyTokenVerificationControllerTest {
     public void setup() {
         organisations = new ArrayList<>();
         organisations.add(new OrganisationalUnit());
-        when(civilServantRegistryClient.getAllOrganisationsFromCache()).thenReturn(organisations);
+        when(civilServantRegistryClient.getAllOrganisations()).thenReturn(organisations);
     }
 
     @Test

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/agencytoken/AgencyTokenVerificationControllerTest.java
@@ -16,11 +16,7 @@ import uk.gov.cabinetoffice.csl.domain.Reactivation;
 import uk.gov.cabinetoffice.csl.dto.*;
 import uk.gov.cabinetoffice.csl.exception.NotEnoughSpaceAvailableException;
 import uk.gov.cabinetoffice.csl.exception.ResourceNotFoundException;
-import uk.gov.cabinetoffice.csl.service.AgencyTokenCapacityService;
-import uk.gov.cabinetoffice.csl.service.EmailUpdateService;
-import uk.gov.cabinetoffice.csl.service.ReactivationService;
-import uk.gov.cabinetoffice.csl.service.VerificationCodeDeterminationService;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
+import uk.gov.cabinetoffice.csl.service.*;
 import uk.gov.cabinetoffice.csl.util.Utils;
 import uk.gov.cabinetoffice.csl.util.WithMockCustomUser;
 
@@ -74,18 +70,18 @@ public class AgencyTokenVerificationControllerTest {
     private ReactivationService reactivationService;
 
     @MockBean
-    private ICivilServantRegistryClient civilServantRegistryClient;
-
-    @MockBean
     private Utils utils;
 
     private List<OrganisationalUnit> organisations;
+
+    @MockBean
+    private CsrsService csrsService;
 
     @BeforeEach
     public void setup() {
         organisations = new ArrayList<>();
         organisations.add(new OrganisationalUnit());
-        when(civilServantRegistryClient.getAllOrganisations()).thenReturn(organisations);
+        when(csrsService.getAllOrganisationalUnits()).thenReturn(organisations);
     }
 
     @Test
@@ -133,7 +129,7 @@ public class AgencyTokenVerificationControllerTest {
         agencyToken.setUid(AGENCY_TOKEN_UID);
 
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(true);
 
         EmailUpdate emailUpdate = new EmailUpdate();
@@ -163,7 +159,7 @@ public class AgencyTokenVerificationControllerTest {
         agencyToken.setUid(AGENCY_TOKEN_UID);
 
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(true);
 
         Reactivation reactivation = new Reactivation();
@@ -193,7 +189,7 @@ public class AgencyTokenVerificationControllerTest {
         agencyToken.setUid(AGENCY_TOKEN_UID);
 
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(false);
 
         EmailUpdate emailUpdate = new EmailUpdate();
@@ -219,7 +215,7 @@ public class AgencyTokenVerificationControllerTest {
         agencyToken.setUid(AGENCY_TOKEN_UID);
 
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(true);
 
         EmailUpdate emailUpdate = new EmailUpdate();
@@ -251,7 +247,7 @@ public class AgencyTokenVerificationControllerTest {
 
         VerificationCodeDetermination verificationCodeDetermination = new VerificationCodeDetermination(EMAIL, EMAIL_UPDATE);
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(false);
         when(verificationCodeDeterminationService.getCodeType(CODE)).thenReturn(verificationCodeDetermination);
         when(emailUpdateService.getEmailUpdateRequestForCode(CODE)).thenThrow(new NotEnoughSpaceAvailableException("No space available"));
@@ -274,7 +270,7 @@ public class AgencyTokenVerificationControllerTest {
         agencyToken.setUid(AGENCY_TOKEN_UID);
 
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(true);
 
         EmailUpdate emailUpdate = new EmailUpdate();
@@ -304,7 +300,7 @@ public class AgencyTokenVerificationControllerTest {
 
         VerificationCodeDetermination verificationCodeDetermination = new VerificationCodeDetermination(EMAIL, EMAIL_UPDATE);
         when(utils.getDomainFromEmailAddress(EMAIL)).thenReturn(DOMAIN);
-        when(civilServantRegistryClient.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
+        when(csrsService.getAgencyToken(DOMAIN, TOKEN, ORGANISATION)).thenReturn(Optional.of(agencyToken));
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(false);
         when(verificationCodeDeterminationService.getCodeType(CODE)).thenReturn(verificationCodeDetermination);
         when(emailUpdateService.getEmailUpdateRequestForCode(CODE)).thenThrow(new NotEnoughSpaceAvailableException("No space available"));

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/signup/SignupControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/signup/SignupControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cabinetoffice.csl.dto.AgencyToken;
 import uk.gov.cabinetoffice.csl.dto.Domain;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
+import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.domain.*;
@@ -79,6 +80,9 @@ public class SignupControllerTest {
     @MockBean
     private AgencyTokenCapacityService agencyTokenCapacityService;
 
+    @MockBean
+    private CsrsService csrsService;
+
     private final Clock clock = Clock.fixed(Instant.parse("2024-01-01T10:00:00.000Z"),
             ZoneId.of("Europe/London"));
 
@@ -86,6 +90,7 @@ public class SignupControllerTest {
     private final String GENERIC_DOMAIN = "domain.com";
     private final String GENERIC_CODE = "ABC123";
     private final String GENERIC_ORG_CODE = "org123";
+
 
     private Invite generateBasicInvite(boolean authorised) {
         Invite i = new Invite();
@@ -439,7 +444,7 @@ public class SignupControllerTest {
 
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getFilteredOrganisations(GENERIC_DOMAIN)).thenReturn(orgs);
+        when(csrsService.getOrganisationalUnitsByDomain(GENERIC_DOMAIN)).thenReturn(orgs);
 
         mockMvc.perform(
                         get("/signup/chooseOrganisation/" + GENERIC_CODE)
@@ -455,7 +460,7 @@ public class SignupControllerTest {
         List<OrganisationalUnit> orgs = Collections.singletonList(org);
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getFilteredOrganisations(GENERIC_DOMAIN)).thenReturn(orgs);
+        when(csrsService.getOrganisationalUnitsByDomain(GENERIC_DOMAIN)).thenReturn(orgs);
         mockMvc.perform(
                         post("/signup/chooseOrganisation/" + GENERIC_CODE)
                                 .with(csrf())
@@ -472,7 +477,8 @@ public class SignupControllerTest {
         List<OrganisationalUnit> orgs = Collections.singletonList(org);
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getFilteredOrganisations(GENERIC_DOMAIN)).thenReturn(orgs);
+        when(csrsService.getOrganisationalUnitsByDomain(GENERIC_DOMAIN)).thenReturn(orgs);
+
         mockMvc.perform(
                         post("/signup/chooseOrganisation/" + GENERIC_CODE)
                                 .with(csrf())

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/signup/SignupControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/signup/SignupControllerTest.java
@@ -17,7 +17,6 @@ import uk.gov.cabinetoffice.csl.dto.Domain;
 import uk.gov.cabinetoffice.csl.dto.OrganisationalUnit;
 import uk.gov.cabinetoffice.csl.service.CsrsService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.domain.*;
 import uk.gov.cabinetoffice.csl.exception.UnableToAllocateAgencyTokenException;
 import uk.gov.cabinetoffice.csl.service.AgencyTokenCapacityService;
@@ -67,9 +66,6 @@ public class SignupControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @MockBean
-    private ICivilServantRegistryClient civilServantRegistryClient;
 
     @MockBean
     private InviteService inviteService;
@@ -523,7 +519,7 @@ public class SignupControllerTest {
     public void shouldReturnEnterToken() throws Exception {
         Invite invite = generateBasicInvite(false);
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.isDomainInAnAgencyTokenWithOrg(GENERIC_DOMAIN, GENERIC_ORG_CODE))
+        when(csrsService.isDomainInAnAgencyTokenWithOrg(GENERIC_DOMAIN, GENERIC_ORG_CODE))
                 .thenReturn(true);
 
         mockMvc.perform(
@@ -559,7 +555,7 @@ public class SignupControllerTest {
         Optional<AgencyToken> optionalAgencyToken = Optional.of(agencyToken);
 
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getAgencyToken(GENERIC_DOMAIN, token, GENERIC_ORG_CODE))
+        when(csrsService.getAgencyToken(GENERIC_DOMAIN, token, GENERIC_ORG_CODE))
                 .thenReturn(optionalAgencyToken);
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(true);
 
@@ -584,7 +580,7 @@ public class SignupControllerTest {
         Optional<AgencyToken> optionalAgencyToken = Optional.of(agencyToken);
 
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getAgencyToken(GENERIC_DOMAIN, token, GENERIC_ORG_CODE))
+        when(csrsService.getAgencyToken(GENERIC_DOMAIN, token, GENERIC_ORG_CODE))
                 .thenReturn(optionalAgencyToken);
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(false);
 
@@ -606,7 +602,7 @@ public class SignupControllerTest {
         Optional<AgencyToken> emptyOptional = Optional.empty();
 
         when(inviteService.getValidInviteForCode(GENERIC_CODE)).thenReturn(invite);
-        when(civilServantRegistryClient.getAgencyToken(GENERIC_DOMAIN, token, GENERIC_ORG_CODE))
+        when(csrsService.getAgencyToken(GENERIC_DOMAIN, token, GENERIC_ORG_CODE))
                 .thenReturn(emptyOptional);
 
         mockMvc.perform(

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/EmailUpdateServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/EmailUpdateServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.cabinetoffice.csl.domain.Identity;
 import uk.gov.cabinetoffice.csl.domain.Role;
 import uk.gov.cabinetoffice.csl.dto.AgencyToken;
 import uk.gov.cabinetoffice.csl.repository.EmailUpdateRepository;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -48,7 +47,7 @@ public class EmailUpdateServiceTest {
     private IdentityService identityService;
 
     @MockBean
-    private ICivilServantRegistryClient civilServantRegistryClient;
+    private CsrsService csrsService;
 
     @Captor
     private ArgumentCaptor<Identity> identityArgumentCaptor;
@@ -87,7 +86,7 @@ public class EmailUpdateServiceTest {
 
         emailUpdateService.updateEmailAddress(emailUpdate);
 
-        verify(civilServantRegistryClient, times(1)).removeOrganisationalUnitFromCivilServant(any());
+        verify(csrsService, times(1)).removeOrganisationalUnitFromCivilServant(any());
         verify(identityService, times(1)).updateEmailAddress(identityArgumentCaptor.capture(),
                 eq(emailUpdate.getNewEmail()), isNull());
 
@@ -113,7 +112,7 @@ public class EmailUpdateServiceTest {
 
         emailUpdateService.updateEmailAddress(emailUpdate, agencyToken);
 
-        verify(civilServantRegistryClient, times(1)).removeOrganisationalUnitFromCivilServant(any());
+        verify(csrsService, times(1)).removeOrganisationalUnitFromCivilServant(any());
         verify(identityService, times(1)).updateEmailAddress(identityArgumentCaptor.capture(),
                 eq(emailUpdate.getNewEmail()), eq(agencyToken));
 

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.cabinetoffice.csl.dto.BatchProcessResponse;
 import uk.gov.cabinetoffice.csl.exception.IdentityNotFoundException;
 import uk.gov.cabinetoffice.csl.repository.CompoundRolesRepository;
 import uk.gov.cabinetoffice.csl.repository.IdentityRepository;
-import uk.gov.cabinetoffice.csl.service.client.csrs.ICivilServantRegistryClient;
 import uk.gov.cabinetoffice.csl.util.Utils;
 
 import java.time.Clock;
@@ -50,9 +49,6 @@ public class IdentityServiceTest {
     private IdentityRepository identityRepository;
 
     @Mock
-    private ICivilServantRegistryClient civilServantRegistryClient;
-
-    @Mock
     private CsrsService csrsService;
 
     @Mock
@@ -69,7 +65,6 @@ public class IdentityServiceTest {
                 agencyTokenCapacityService,
                 identityRepository,
                 new CompoundRolesRepository(),
-                civilServantRegistryClient,
                 csrsService,
                 passwordEncoder,
                 utils,
@@ -171,7 +166,7 @@ public class IdentityServiceTest {
         agencyToken.setToken(tokenToken);
 
         when(inviteService.getInviteForCode(code)).thenReturn(invite);
-        when(civilServantRegistryClient.getAgencyToken(tokenDomain, tokenToken, tokenCode))
+        when(csrsService.getAgencyToken(tokenDomain, tokenToken, tokenCode))
                 .thenReturn(Optional.of(agencyToken));
         when(passwordEncoder.encode("password")).thenReturn("password");
         when(agencyTokenCapacityService.hasSpaceAvailable(agencyToken)).thenReturn(true);

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
@@ -129,7 +129,7 @@ public class IdentityServiceTest {
 
         when(inviteService.getInviteForCode(code)).thenReturn(invite);
         when(passwordEncoder.encode("password")).thenReturn("password");
-        when(csrsService.domainIsAllowlisted(domain)).thenReturn(true);
+        when(csrsService.isDomainAllowlisted(domain)).thenReturn(true);
 
         identityService.createIdentityFromInviteCode(code, "password", agencyToken);
 

--- a/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/service/IdentityServiceTest.java
@@ -53,6 +53,9 @@ public class IdentityServiceTest {
     private ICivilServantRegistryClient civilServantRegistryClient;
 
     @Mock
+    private CsrsService csrsService;
+
+    @Mock
     private PasswordEncoder passwordEncoder;
 
     private final Utils utils = new Utils();
@@ -67,6 +70,7 @@ public class IdentityServiceTest {
                 identityRepository,
                 new CompoundRolesRepository(),
                 civilServantRegistryClient,
+                csrsService,
                 passwordEncoder,
                 utils,
                 clock
@@ -125,7 +129,7 @@ public class IdentityServiceTest {
 
         when(inviteService.getInviteForCode(code)).thenReturn(invite);
         when(passwordEncoder.encode("password")).thenReturn("password");
-        when(civilServantRegistryClient.isDomainAllowListed(domain)).thenReturn(true);
+        when(csrsService.domainIsAllowlisted(domain)).thenReturn(true);
 
         identityService.createIdentityFromInviteCode(code, "password", agencyToken);
 


### PR DESCRIPTION
This change:

* Create a new service `CsrsService`
* Create new functions in `CsrsService`: `domainIsAllowlisted()`, `getAllOrganisationalUnits()`, `getOrganisationalUnitsByDomain()` and `domainIsValid()`.
* Refactor `CivilServantRegistryClient` to combine and rename methods.
* Refactor various classes to call `CsrsService` instead of `CivilServantRegistryClient`