### PR TITLE
LC-3245-Delete redundant oAuth tables from Identity DB

### DIFF
--- a/src/main/resources/db/migration/mysql/V1.12.0__drop-redundant-auth-tables.sql
+++ b/src/main/resources/db/migration/mysql/V1.12.0__drop-redundant-auth-tables.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS client;
+DROP TABLE IF EXISTS duplicates_history;
+DROP TABLE IF EXISTS oauth_code;
+DROP TABLE IF EXISTS token;


### PR DESCRIPTION
The following redundant oAuth tables are deleted from the identity database:
- client
- duplicates_history
- oauth_code
- token