### PR TITLE
LC 3054 change email logout

### DIFF
--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateController.java
@@ -15,6 +15,7 @@ import uk.gov.cabinetoffice.csl.domain.EmailUpdate;
 import uk.gov.cabinetoffice.csl.domain.Identity;
 import uk.gov.cabinetoffice.csl.dto.IdentityDetails;
 import uk.gov.cabinetoffice.csl.service.EmailUpdateService;
+import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.util.LogoutUtil;
 import uk.gov.cabinetoffice.csl.util.Utils;
@@ -28,9 +29,6 @@ import static uk.gov.cabinetoffice.csl.util.ApplicationConstants.*;
 @Controller
 @RequestMapping("/account/email")
 public class EmailUpdateController {
-
-    private static final String LPG_UI_SIGNOUT_URL_ATTRIBUTE = "lpgUiSignOutUrl";
-    private static final String LPG_UI_SIGNOUT_TIMER_ATTRIBUTE = "signOutTimerInSeconds";
     private static final String LPG_UI_URL_ATTRIBUTE = "lpgUiUrl";
     private static final String EMAIL_ATTRIBUTE = "email";
     private static final String UPDATED_EMAIL_ATTRIBUTE = "updatedEmail";
@@ -55,12 +53,6 @@ public class EmailUpdateController {
     @Value("${lpg.uiUrl}")
     private String lpgUiUrl;
 
-    @Value("${lpg.uiSignOutUrl}")
-    private String lpgUiSignOutUrl;
-
-    @Value("${lpg.signOutTimerInSeconds}")
-    private int signOutTimerInSeconds;
-
     @Value("${lpg.contactEmail}")
     private String contactEmail;
 
@@ -68,16 +60,18 @@ public class EmailUpdateController {
     private String contactNumber;
 
     private final IdentityService identityService;
+    private final FrontendService frontendService;
     private final EmailUpdateService emailUpdateService;
     private final Utils utils;
     private final LogoutUtil logoutUtil;
     private final int validityInSeconds;
 
     public EmailUpdateController(IdentityService identityService,
-                                 EmailUpdateService emailUpdateService,
+                                 FrontendService frontendService, EmailUpdateService emailUpdateService,
                                  Utils utils, LogoutUtil logoutUtil,
                                  @Value("${emailUpdate.validityInSeconds}") int validityInSeconds) {
         this.identityService = identityService;
+        this.frontendService = frontendService;
         this.emailUpdateService = emailUpdateService;
         this.utils = utils;
         this.logoutUtil = logoutUtil;
@@ -119,17 +113,15 @@ public class EmailUpdateController {
 
         Identity identity = ((IdentityDetails) authentication.getPrincipal()).getIdentity();
         emailUpdateService.saveEmailUpdateAndNotify(identity, newEmail);
-
+        model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
         model.addAttribute("resetValidity", utils.convertSecondsIntoDaysHoursMinutesSeconds(validityInSeconds));
-        model.addAttribute(LPG_UI_SIGNOUT_URL_ATTRIBUTE, lpgUiSignOutUrl);
-        model.addAttribute(LPG_UI_SIGNOUT_TIMER_ATTRIBUTE, signOutTimerInSeconds);
         return EMAIL_VERIFICATION_SENT_TEMPLATE;
     }
 
     @GetMapping("/verify/{code}")
     public String verifyEmail(@PathVariable String code, Authentication authentication,
                               HttpServletRequest request, HttpServletResponse response,
-                              RedirectAttributes redirectAttributes) {
+                              RedirectAttributes redirectAttributes, Model model) {
         log.debug("Attempting update email verification with code: {}", code);
 
         Object principal = authentication != null ? authentication.getPrincipal() : null;
@@ -177,8 +169,10 @@ public class EmailUpdateController {
             try {
                 emailUpdateService.updateEmailAddress(emailUpdate);
                 log.debug("Email updated successfully from old email = {} to newEmail = {}", oldEmail, newEmail);
-                redirectAttributes.addFlashAttribute(EMAIL_ATTRIBUTE, newEmail);
-                return REDIRECT_ACCOUNT_EMAIL_UPDATED_SUCCESS;
+                frontendService.signoutUser();
+                model.addAttribute(UPDATED_EMAIL_ATTRIBUTE, newEmail);
+                model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
+                return EMAIL_UPDATED_TEMPLATE;
             } catch (Exception e) {
                 redirectAttributes.addFlashAttribute(STATUS_ATTRIBUTE, CHANGE_EMAIL_ERROR_MESSAGE);
                 log.error("Unable to update old email = {} to newEmail = {}. Exception: {}", oldEmail, newEmail
@@ -198,8 +192,7 @@ public class EmailUpdateController {
         Map<String, Object> modelMap = model.asMap();
         String updatedEmail = String.valueOf(modelMap.get(EMAIL_ATTRIBUTE));
         model.addAttribute(UPDATED_EMAIL_ATTRIBUTE, updatedEmail);
-        model.addAttribute(LPG_UI_SIGNOUT_URL_ATTRIBUTE, lpgUiSignOutUrl);
-        model.addAttribute(LPG_UI_SIGNOUT_TIMER_ATTRIBUTE, signOutTimerInSeconds);
+        model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
         return EMAIL_UPDATED_TEMPLATE;
     }
 

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateController.java
@@ -114,14 +114,13 @@ public class EmailUpdateController {
         Identity identity = ((IdentityDetails) authentication.getPrincipal()).getIdentity();
         emailUpdateService.saveEmailUpdateAndNotify(identity, newEmail);
         model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
-        model.addAttribute("resetValidity", utils.convertSecondsIntoDaysHoursMinutesSeconds(validityInSeconds));
         return EMAIL_VERIFICATION_SENT_TEMPLATE;
     }
 
     @GetMapping("/verify/{code}")
     public String verifyEmail(@PathVariable String code, Authentication authentication,
                               HttpServletRequest request, HttpServletResponse response,
-                              RedirectAttributes redirectAttributes, Model model) {
+                              RedirectAttributes redirectAttributes) {
         log.debug("Attempting update email verification with code: {}", code);
 
         Object principal = authentication != null ? authentication.getPrincipal() : null;
@@ -170,9 +169,8 @@ public class EmailUpdateController {
                 emailUpdateService.updateEmailAddress(emailUpdate);
                 log.debug("Email updated successfully from old email = {} to newEmail = {}", oldEmail, newEmail);
                 frontendService.signoutUser();
-                model.addAttribute(UPDATED_EMAIL_ATTRIBUTE, newEmail);
-                model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
-                return EMAIL_UPDATED_TEMPLATE;
+                redirectAttributes.addFlashAttribute(EMAIL_ATTRIBUTE, newEmail);
+                return REDIRECT_ACCOUNT_EMAIL_UPDATED_SUCCESS;
             } catch (Exception e) {
                 redirectAttributes.addFlashAttribute(STATUS_ATTRIBUTE, CHANGE_EMAIL_ERROR_MESSAGE);
                 log.error("Unable to update old email = {} to newEmail = {}. Exception: {}", oldEmail, newEmail

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateController.java
@@ -113,6 +113,7 @@ public class EmailUpdateController {
 
         Identity identity = ((IdentityDetails) authentication.getPrincipal()).getIdentity();
         emailUpdateService.saveEmailUpdateAndNotify(identity, newEmail);
+        model.addAttribute("resetValidity", utils.convertSecondsIntoDaysHoursMinutesSeconds(validityInSeconds));
         model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
         return EMAIL_VERIFICATION_SENT_TEMPLATE;
     }

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/passwordupdate/UpdatePasswordController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/passwordupdate/UpdatePasswordController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.cabinetoffice.csl.dto.IdentityDetails;
+import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.PasswordService;
 
 @Controller
@@ -19,20 +20,15 @@ public class UpdatePasswordController {
 
     private static final String UPDATE_PASSWORD_TEMPLATE = "passwordupdate/updatePassword";
     private static final String PASSWORD_UPDATED_TEMPLATE = "passwordupdate/passwordUpdated";
-    private static final String REDIRECT_PASSWORD_UPDATED = "redirect:/account/password/passwordUpdated";
-    private static final String LPG_UI_SIGNOUT_TIMER_ATTRIBUTE = "signOutTimerInSeconds";
-    private static final String LPG_UI_SIGNOUT_URL_ATTRIBUTE = "lpgUiSignOutUrl";
-
-    @Value("${lpg.uiSignOutUrl}")
-    private String lpgUiSignOutUrl;
-
-    @Value("${lpg.signOutTimerInSeconds}")
-    private int signOutTimerInSeconds;
-
+    private static final String LPG_UI_URL_ATTRIBUTE = "lpgUiUrl";
+    @Value("${lpg.uiUrl}")
+    private String lpgUiUrl;
     private final PasswordService passwordService;
+    private final FrontendService frontendService;
 
-    public UpdatePasswordController(PasswordService passwordService) {
+    public UpdatePasswordController(PasswordService passwordService, FrontendService frontendService) {
         this.passwordService = passwordService;
+        this.frontendService = frontendService;
     }
 
     @GetMapping
@@ -53,13 +49,8 @@ public class UpdatePasswordController {
         passwordService.updatePasswordAndNotify(
                 ((IdentityDetails) authentication.getPrincipal()).getIdentity(),
                 form.getNewPassword());
-        return REDIRECT_PASSWORD_UPDATED;
-    }
-
-    @GetMapping("/passwordUpdated")
-    public String passwordUpdated(Model model) {
-        model.addAttribute(LPG_UI_SIGNOUT_URL_ATTRIBUTE, lpgUiSignOutUrl);
-        model.addAttribute(LPG_UI_SIGNOUT_TIMER_ATTRIBUTE, signOutTimerInSeconds);
+        frontendService.signoutUser();
+        model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
         return PASSWORD_UPDATED_TEMPLATE;
     }
 }

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/reset/ResetController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/reset/ResetController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.cabinetoffice.csl.domain.Identity;
 import uk.gov.cabinetoffice.csl.domain.Reset;
+import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.PasswordService;
 import uk.gov.cabinetoffice.csl.service.ResetService;
@@ -29,9 +30,10 @@ public class ResetController {
     private static final String PENDING_RESET_TEMPLATE = "reset/pendingReset";
     private static final String PASSWORD_FORM_TEMPLATE = "reset/passwordForm";
     private static final String PASSWORD_RESET_TEMPLATE = "reset/passwordReset";
+    private static final String LPG_UI_URL_ATTRIBUTE = "lpgUiUrl";
 
-    @Value("${lpg.uiSignOutUrl}")
-    private String lpgUiSignOutUrl;
+    @Value("${lpg.uiUrl}")
+    private String lpgUiUrl;
 
     @Value("${lpg.contactEmail}")
     private String contactEmail;
@@ -45,13 +47,16 @@ public class ResetController {
 
     private final IdentityService identityService;
 
+    private final FrontendService frontendService;
+
     private final ResetFormValidator resetFormValidator;
 
     public ResetController(ResetService resetService, PasswordService passwordService,
-                           IdentityService identityService, ResetFormValidator resetFormValidator) {
+                           FrontendService frontendService, IdentityService identityService, ResetFormValidator resetFormValidator) {
         this.resetService = resetService;
         this.passwordService = passwordService;
         this.identityService = identityService;
+        this.frontendService = frontendService;
         this.resetFormValidator = resetFormValidator;
     }
 
@@ -129,7 +134,8 @@ public class ResetController {
             passwordService.updatePasswordAndActivateAndUnlock(identity, resetForm.getPassword());
             resetService.notifyUserForSuccessfulReset(reset);
             log.info("Reset success sent to {}", reset.getEmail());
-            model.addAttribute("lpgUiSignOutUrl", lpgUiSignOutUrl);
+            frontendService.signoutUser();
+            model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
             return PASSWORD_RESET_TEMPLATE;
         }
         return result;

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/FrontendService.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/FrontendService.java
@@ -1,0 +1,24 @@
+package uk.gov.cabinetoffice.csl.service;
+
+import org.springframework.stereotype.Component;
+import uk.gov.cabinetoffice.csl.domain.Identity;
+import uk.gov.cabinetoffice.csl.dto.IdentityDetails;
+import uk.gov.cabinetoffice.csl.service.auth2.IUserAuthService;
+import uk.gov.cabinetoffice.csl.service.client.frontend.IFrontendClient;
+
+@Component
+public class FrontendService {
+
+    private final IFrontendClient frontendClient;
+    private final IUserAuthService userAuthService;
+    public FrontendService(IFrontendClient frontendClient, IUserAuthService userAuthService) {
+        this.frontendClient = frontendClient;
+        this.userAuthService = userAuthService;
+    }
+
+    public void signoutUser() {
+        IdentityDetails identity = (IdentityDetails) userAuthService.getAuthentication().getPrincipal();
+        frontendClient.signOutUser(identity.getIdentity().getUid());
+    }
+
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/client/frontend/FrontendClient.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/client/frontend/FrontendClient.java
@@ -1,0 +1,32 @@
+package uk.gov.cabinetoffice.csl.service.client.frontend;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import uk.gov.cabinetoffice.csl.service.client.IHttpClient;
+
+import static java.lang.String.format;
+
+@Component
+@Slf4j
+public class FrontendClient implements IFrontendClient {
+
+    private final IHttpClient client;
+
+    private final String logoutUserEndpoint;
+
+    public FrontendClient(@Qualifier("lpgUiClient") IHttpClient client, @Value("${lpg.SignoutEndpoint}") String logoutUserEndpoint) {
+        this.client = client;
+        this.logoutUserEndpoint = logoutUserEndpoint;
+    }
+
+    @Override
+    public void signOutUser(String uid) {
+        log.info("Signing current user out");
+        String url = format(logoutUserEndpoint, uid);
+        RequestEntity<Void> request = RequestEntity.post(url).build();
+        client.executeRequest(request, Void.class);
+    }
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/client/frontend/FrontendClientConfig.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/client/frontend/FrontendClientConfig.java
@@ -1,0 +1,33 @@
+package uk.gov.cabinetoffice.csl.service.client.frontend;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.cabinetoffice.csl.service.auth2.RestTemplateOAuthInterceptor;
+import uk.gov.cabinetoffice.csl.service.client.HttpClient;
+import uk.gov.cabinetoffice.csl.service.client.IHttpClient;
+
+@Configuration
+public class FrontendClientConfig {
+
+    private final String lpgUiBaseUrl;
+
+    private final RestTemplateOAuthInterceptor restTemplateOAuthInterceptor;
+
+    public FrontendClientConfig(@Value("${lpg.uiUrl}") String lpgUiBaseUrl, RestTemplateOAuthInterceptor restTemplateOAuthInterceptor) {
+        this.lpgUiBaseUrl = lpgUiBaseUrl;
+        this.restTemplateOAuthInterceptor = restTemplateOAuthInterceptor;
+    }
+
+    @Bean(name = "lpgUiClient")
+    IHttpClient identityClient(RestTemplateBuilder restTemplateBuilder) {
+        RestTemplate restTemplate = restTemplateBuilder
+                .rootUri(lpgUiBaseUrl)
+                .interceptors(restTemplateOAuthInterceptor)
+                .build();
+        return new HttpClient(restTemplate);
+    }
+
+}

--- a/src/main/java/uk/gov/cabinetoffice/csl/service/client/frontend/IFrontendClient.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/service/client/frontend/IFrontendClient.java
@@ -1,0 +1,7 @@
+package uk.gov.cabinetoffice.csl.service.client.frontend;
+
+public interface IFrontendClient {
+
+    void signOutUser(String uid);
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -76,13 +76,13 @@ spring.datasource.password=${DATASOURCE_PASSWORD:sa}
 #spring.datasource.driver-class-name=${DATASOURCE_DRIVER_CLASS_NAME:com.mysql.cj.jdbc.Driver}
 #spring.datasource.url=${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=false}
 #spring.datasource.username=${DATASOURCE_USERNAME:root}
-#spring.datasource.password=${DATASOURCE_PASSWORD:password}
+#spring.datasource.password=${DATASOURCE_PASSWORD:my-secret-pw}
 
 ## Redis cache properties for caching the service-token
 spring.data.redis.repositories.enabled=false
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
-spring.data.redis.password=${REDIS_PASSWORD:ChangeMe}
+spring.data.redis.password=${REDIS_PASSWORD:}
 spring.cache.type=${CACHE_TYPE:redis}
 spring.cache.redis.key-prefix=${REDIS_KEY_PREFIX:csl-identity_}
 spring.cache.redis.use-key-prefix=${REDIS_USE_KEY_PREFIX:true}
@@ -102,16 +102,14 @@ spring.jackson.deserialization.fail-on-unknown-properties=false
 
 ## lpg-services properties
 lpg.uiUrl=${LPG_UI_URL:http://localhost:3001}
-lpg.uiSignOutUri=${LPG_UI_SIGNOUT_URI:/sign-out}
-lpg.uiSignOutUrl=${lpg.uiUrl}${lpg.uiSignOutUri}
-lpg.signOutTimerInSeconds=${LPG_SIGNOUT_TIMER_SECONDS:5}
+lpg.SignoutEndpoint=${LPG_UI_SIGNOUT_ENDPOINT:/api/caches/user/%s/logout}
 lpg.contactEmail=${CONTACT_EMAIL:support@governmentcampus.co.uk}
 lpg.contactNumber=${CONTACT_NUMBER:020 3640 7985}
 
 ## oAuth2.0 properties
 oauth2.jwtKey=${JWT_KEY:ChangeMe}
 oauth2.scope=${ACCESS_TOKEN_SCOPE:openid, read, write}
-oauth2.serviceUrl=${OAUTH2_SERVICE_URL:http://localhost:9005}
+oauth2.serviceUrl=${OAUTH2_SERVICE_URL:http://localhost:8080}
 oauth2.tokenUrl=${OAUTH2_TOKEN_ENDPOINT:/oauth2/token}
 oauth2.clientId=${CLIENT_ID:ChangeMe}
 oauth2.clientSecret=${CLIENT_SECRET:ChangeMe}

--- a/src/main/resources/static/assets/js/auto-logout.js
+++ b/src/main/resources/static/assets/js/auto-logout.js
@@ -1,8 +1,0 @@
-setInterval(function() {
-    const div = document.querySelector("#signOutTimerInSeconds");
-    const count = div.textContent * 1 - 1;
-    div.textContent = count;
-    if (count <= 0) {
-        window.location.replace(document.querySelector("#signOutLink").textContent);
-    }
-}, 1000);

--- a/src/main/resources/templates/emailupdate/emailUpdated.html
+++ b/src/main/resources/templates/emailupdate/emailUpdated.html
@@ -3,25 +3,24 @@
 <content>
 <div class="container">
     <div class="grid-row">
-        <div class="govuk-box-highlight">
-            <h1 class="heading-xlarge">Email update complete</h1>
-            <p class="font-medium">
-                Your updated email address<br>
-                <strong><span th:text="${updatedEmail}">email</span></strong>
-            </p>
-        </div>
-        <div hidden id="signOutTimerInSeconds"><span th:text="${signOutTimerInSeconds}"></span></div>
-        <div hidden id="signOutLink"><span th:text="${lpgUiSignOutUrl}"></span></div>
-        <div class="grid-row push-bottom">
-            <div class="column-two-thirds">
-                <h2 class="heading-medium">What happens next?</h2>
-                <p>You can now <a th:href="${lpgUiSignOutUrl}">login</a> to the Learning Platform for
-                    Government with your new email.</p>
-                <a href="/reset" class="push-bottom">Forgotten your password?</a>
+        <div class="column-full">
+            <div class="govuk-box-highlight">
+                <h1 class="heading-xlarge">Email update complete</h1>
+                <p class="font-medium">
+                    Your updated email address<br>
+                    <strong><span th:text="${updatedEmail}">email</span></strong>
+                </p>
             </div>
         </div>
     </div>
+    <div class="grid-row push-bottom">
+        <div class="column-two-thirds">
+            <h2 class="heading-medium">What happens next?</h2>
+            <p>You can now <a th:href="${lpgUiUrl}">login</a> to the Learning Platform for
+                Government with your new email.</p>
+            <a href="/reset" class="push-bottom">Forgotten your password?</a>
+        </div>
+    </div>
 </div>
-<script type="text/javascript" src="/assets/js/auto-logout.js"></script>
 </content>
 </page>

--- a/src/main/resources/templates/emailupdate/emailVerificationSent.html
+++ b/src/main/resources/templates/emailupdate/emailVerificationSent.html
@@ -3,20 +3,19 @@
 <content>
 <div class="container">
     <div class="grid-row">
-        <div class="govuk-box-highlight">
-            <h1 class="heading-xlarge">Email update requested</h1>
-            <p class="font-medium">You have requested to change your email</p>
-        </div>
-        <div class="grid-row push-bottom">
-            <div class="column-two-thirds">
-                <h2 class="heading-medium">What happens next?</h2>
-                <p>We have sent you an email with a link to your new email address.</p>
-                <p>Please click on the link in the email to verify changes to your account.</p>
-                <p>The link will expire in <span th:text="${resetValidity}"></span></p>
-                <p>Please click here to <a th:href="${lpgUiSignOutUrl}">sign out</a> and check your email.</p>
+        <div class="column-full">
+            <div class="govuk-box-highlight">
+                <h1 class="heading-xlarge">Email update requested</h1>
+                <p class="font-medium">You have requested to change your email</p>
             </div>
-            <div hidden id="signOutTimerInSeconds"><span th:text="${signOutTimerInSeconds}"></span></div>
-            <div hidden id="signOutLink"><span th:text="${lpgUiSignOutUrl}"></span></div>
+        </div>
+    </div>
+    <div class="grid-row push-bottom">
+        <div class="column-two-thirds">
+            <h2 class="heading-medium">What happens next?</h2>
+            <p>We have sent you an email with a link to your new email address.</p>
+            <p>Please click on the link in the email to verify changes to your account.</p>
+            <p>The link will expire in <span th:text="${resetValidity}"></span>.</p>
             <details role="group">
                 <summary role="button" aria-controls="details-content-0" aria-expanded="false">
                     <span class="summary">Haven't received the email?</span>
@@ -34,6 +33,5 @@
         </div>
     </div>
 </div>
-<script type="text/javascript" src="/assets/js/auto-logout.js"></script>
 </content>
 </page>

--- a/src/main/resources/templates/passwordupdate/passwordUpdated.html
+++ b/src/main/resources/templates/passwordupdate/passwordUpdated.html
@@ -5,12 +5,9 @@
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large">Your password has been updated</h1>
-            <p>Please <a th:href="${lpgUiSignOutUrl}">sign out</a> to continue</p>
+            <p>Please <a th:href="${lpgUiUrl}">sign in</a> to continue</p>
         </div>
-        <div hidden id="signOutTimerInSeconds"><span th:text="${signOutTimerInSeconds}"></span></div>
-        <div hidden id="signOutLink"><span th:text="${lpgUiSignOutUrl}"></span></div>
     </div>
 </div>
-<script type="text/javascript" src="/assets/js/auto-logout.js"></script>
 </content>
 </page>

--- a/src/main/resources/templates/reset/passwordReset.html
+++ b/src/main/resources/templates/reset/passwordReset.html
@@ -9,7 +9,7 @@
     <div class="grid-row push-bottom">
         <div class="column-two-thirds">
             <h2 class="heading-medium">What happens next?</h2>
-            <p>You can now <a th:href="${lpgUiSignOutUrl}">sign into the Learning Platform for Government</a> with your new password.</p>
+            <p>You can now <a th:href="${lpgUiUrl}">sign into the Learning Platform for Government</a> with your new password.</p>
         </div>
     </div>
 </div>

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateCompletionWhileNotLoggedInEmailUpdateControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/emailupdate/EmailUpdateCompletionWhileNotLoggedInEmailUpdateControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.cabinetoffice.csl.controller.emailupdate;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,6 +46,9 @@ public class EmailUpdateCompletionWhileNotLoggedInEmailUpdateControllerTest {
 
     @MockBean
     private IdentityService identityService;
+
+    @MockBean
+    private FrontendService frontendService;
 
     @MockBean
     private EmailUpdateService emailUpdateService;
@@ -138,6 +142,7 @@ public class EmailUpdateCompletionWhileNotLoggedInEmailUpdateControllerTest {
                 .andDo(print());
 
         verify(emailUpdateService, times(1)).updateEmailAddress(eq(emailUpdate));
+        verify(frontendService, times(1)).signoutUser();
     }
 
     @Test

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/passwordupdate/UpdatePasswordControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/passwordupdate/UpdatePasswordControllerTest.java
@@ -10,13 +10,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cabinetoffice.csl.domain.Identity;
+import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.PasswordService;
 import uk.gov.cabinetoffice.csl.util.TestUtil;
 import uk.gov.cabinetoffice.csl.util.WithMockCustomUser;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -41,6 +42,9 @@ public class UpdatePasswordControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private FrontendService frontendService;
 
     @MockBean
     private PasswordService passwordService;
@@ -95,21 +99,13 @@ public class UpdatePasswordControllerTest {
                         .param("confirm", PASSWORD)
                         .with(csrf())
                 )
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl(REDIRECT_PASSWORD_UPDATED))
-                .andDo(print());
-    }
-
-    @Test
-    public void shouldLoadPasswordUpdatedScreen() throws Exception {
-        mockMvc.perform(
-                        get("/account/password/passwordUpdated")
-                                .with(csrf())
-                )
                 .andExpect(status().isOk())
                 .andExpect(view().name(PASSWORD_UPDATED_TEMPLATE))
                 .andExpect(content().string(containsString("Your password has been updated")))
-                .andExpect(model().attributeExists("lpgUiSignOutUrl"))
+                .andExpect(model().attributeExists("lpgUiUrl"))
                 .andDo(print());
+
+        verify(frontendService, times(1)).signoutUser();
     }
+
 }

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/reset/ResetControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/reset/ResetControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.cabinetoffice.csl.controller.reset;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,6 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cabinetoffice.csl.domain.Identity;
 import uk.gov.cabinetoffice.csl.domain.Reset;
+import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.ResetService;
 import uk.gov.cabinetoffice.csl.util.TestUtil;
@@ -20,7 +22,7 @@ import java.time.LocalDateTime;
 
 import static java.time.Month.FEBRUARY;
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -49,6 +51,9 @@ public class ResetControllerTest {
 
     @MockBean
     private ResetService resetService;
+
+    @MockBean
+    private FrontendService frontendService;
 
     @MockBean
     private IdentityService identityService;
@@ -431,8 +436,10 @@ public class ResetControllerTest {
                 .andExpect(content().string(containsString("Password reset complete")))
                 .andExpect(content().string(containsString("Your new password has been changed")))
                 .andExpect(content().string(containsString("What happens next?")))
-                .andExpect(model().attributeExists("lpgUiSignOutUrl"))
+                .andExpect(model().attributeExists("lpgUiUrl"))
                 .andDo(print());
+
+        verify(frontendService, atMostOnce()).signoutUser();
     }
 
     private Reset createReset() {


### PR DESCRIPTION
- Introduce frontend client configuration. This allows identity service to communicate with the frontend server using JWT
- Use new API to log user out for the following actions
    - Change email address
    - Change password
- Remove Javascript redirect for the above actions