### PR TITLE
LC-3361-GenericServerException after resetting the account

### DIFF
--- a/.run-1/csl-identity-service[mvn-boot-run].run.xml
+++ b/.run-1/csl-identity-service[mvn-boot-run].run.xml
@@ -66,7 +66,7 @@
               <entry key="REDIS_PASSWORD" value="password" />
               <entry key="REDIS_PORT" value="6379" />
               <entry key="REDIS_USE_KEY_PREFIX" value="true" />
-              <entry key="REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE" value="0" />
+              <entry key="REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE" value="5" />
               <entry key="REFRESH_TOKEN_TTL_SECONDS" value="86400" />
               <entry key="RESET_VALIDITY_SECONDS" value="86400" />
               <entry key="ROOT_LOGGING_LEVEL" value="INFO" />

--- a/.run/CslIdentityService[spring-boot-run].run.xml
+++ b/.run/CslIdentityService[spring-boot-run].run.xml
@@ -61,7 +61,7 @@
       <env name="REDIS_PASSWORD" value="password" />
       <env name="REDIS_PORT" value="6379" />
       <env name="REDIS_USE_KEY_PREFIX" value="true" />
-      <env name="REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE" value="0" />
+      <env name="REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE" value="5" />
       <env name="REFRESH_TOKEN_TTL_SECONDS" value="86400" />
       <env name="RESET_VALIDITY_SECONDS" value="86400" />
       <env name="ROOT_LOGGING_LEVEL" value="INFO" />

--- a/src/main/java/uk/gov/cabinetoffice/csl/controller/reset/ResetController.java
+++ b/src/main/java/uk/gov/cabinetoffice/csl/controller/reset/ResetController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.cabinetoffice.csl.domain.Identity;
 import uk.gov.cabinetoffice.csl.domain.Reset;
-import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.PasswordService;
 import uk.gov.cabinetoffice.csl.service.ResetService;
@@ -55,19 +54,15 @@ public class ResetController {
 
     private final IdentityService identityService;
 
-    private final FrontendService frontendService;
-
     private final ResetFormValidator resetFormValidator;
 
     private final Clock clock;
 
     public ResetController(ResetService resetService, PasswordService passwordService,
-                           FrontendService frontendService, IdentityService identityService,
-                           ResetFormValidator resetFormValidator, Clock clock) {
+                           IdentityService identityService, ResetFormValidator resetFormValidator, Clock clock) {
         this.resetService = resetService;
         this.passwordService = passwordService;
         this.identityService = identityService;
-        this.frontendService = frontendService;
         this.resetFormValidator = resetFormValidator;
         this.clock = clock;
     }
@@ -155,7 +150,6 @@ public class ResetController {
             passwordService.updatePasswordAndActivateAndUnlock(identity, resetForm.getPassword());
             resetService.notifyUserForSuccessfulReset(reset);
             log.info("Account is reset successfully for {}", reset.getEmail());
-            frontendService.signoutUser(identity.getUid());
             model.addAttribute(LPG_UI_URL_ATTRIBUTE, lpgUiUrl);
             return PASSWORD_RESET_TEMPLATE;
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -113,7 +113,7 @@ oauth2.serviceUrl=${OAUTH2_SERVICE_URL:http://localhost:8080}
 oauth2.tokenUrl=${OAUTH2_TOKEN_ENDPOINT:/oauth2/token}
 oauth2.clientId=${CLIENT_ID:ChangeMe}
 oauth2.clientSecret=${CLIENT_SECRET:ChangeMe}
-oauth2.refresh.serviceTokenCache.beforeSecondsToExpire=${REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE:0}
+oauth2.refresh.serviceTokenCache.beforeSecondsToExpire=${REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE:5}
 
 ## csl-identity-service properties
 time.zoneId=${TIME_ZONE_ID:UTC}

--- a/src/test/java/uk/gov/cabinetoffice/csl/controller/reset/ResetControllerTest.java
+++ b/src/test/java/uk/gov/cabinetoffice/csl/controller/reset/ResetControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cabinetoffice.csl.domain.Identity;
 import uk.gov.cabinetoffice.csl.domain.Reset;
-import uk.gov.cabinetoffice.csl.service.FrontendService;
 import uk.gov.cabinetoffice.csl.service.IdentityService;
 import uk.gov.cabinetoffice.csl.service.ResetService;
 import uk.gov.cabinetoffice.csl.util.TestUtil;
@@ -44,16 +43,12 @@ public class ResetControllerTest {
     private static final String EMAIL = "test@example.com";
     private static final String PASSWORD = "Password123";
     private static final String CODE = "abc123";
-    private final int durationAfterResetAllowedInSeconds = 3600;
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private ResetService resetService;
-
-    @MockBean
-    private FrontendService frontendService;
 
     @MockBean
     private IdentityService identityService;
@@ -126,6 +121,8 @@ public class ResetControllerTest {
 
     @Test
     public void shouldLoadCheckEmailPageIfUserTryToResetAgainAfterResetAllowedDuration() throws Exception {
+        final int durationAfterResetAllowedInSeconds = 3600;
+
         when(identityService.isIdentityExistsForEmail(EMAIL)).thenReturn(true);
         Reset reset = createReset();
         reset.setRequestedAt(now(clock).minusSeconds(durationAfterResetAllowedInSeconds));
@@ -461,8 +458,6 @@ public class ResetControllerTest {
                 .andExpect(content().string(containsString("What happens next?")))
                 .andExpect(model().attributeExists("lpgUiUrl"))
                 .andDo(print());
-
-        verify(frontendService, atMostOnce()).signoutUser(UID);
     }
 
     private Reset createReset() {


### PR DESCRIPTION
A. Changes:
1. frontendService.signoutUser() call is removed because it is redundant for the account reset feature.
2. REFRESH_SERVICE_TOKEN_CACHE_SECONDS_BEFORE_TO_EXPIRE setting is changed from 0 to 5 seconds in-line with prod environment.

B. Testing evidence document: https://cshrdigitalandanalysis.atlassian.net/wiki/spaces/LPG/pages/3862265857/LC-3361-GenericServerException+after+resetting+the+account